### PR TITLE
[do not merge] WIP - Refactor site to remove Bootstrap and apply custom 'Field Notes' style

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,3 @@
-<div class="container">
-  <footer class="py-3 my-4">
-	  <p class="text-center text-muted">Ekipa Fanihy</p>
-  </footer>
-</div>
+<footer>
+  <p>Ekipa Fanihy</p>
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,6 @@
   <title>{{ page.title | escape }} - Ekipa Fanihy</title>
 {% endif %}
 
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
   <link rel="stylesheet" type="text/css" href="/assets/style.css" />
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">

--- a/_includes/header-mg.html
+++ b/_includes/header-mg.html
@@ -1,18 +1,8 @@
 <header>
-	<nav class="navbar navbar-expand-lg navbar-light bg-light rounded" aria-label="navbar">
-		<div class="container-fluid">
-		  <a class="navbar-brand" href="/index-mg">🦇 Ekipa Fanihy</a>
-		  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
-			<span class="navbar-toggler-icon"></span>
-		  </button>
-	
-		  <div class="collapse navbar-collapse" id="navbar">
-			<ul class="navbar-nav me-auto mb-2 mb-md-0">
-			  <li class="nav-item"><a class="nav-link{% if page.title == "Asa" %} active{% endif %}" href="/work-mg">Asa</a></li>
-			  <li class="nav-item"><a class="nav-link{% if page.title == "Ekipa" %} active{% endif %}" href="/team-mg">Ekipa</a></li>
-			  <li class="nav-item"><a class="nav-link" href="/index">🇺🇸</a></li>
-			</ul>
-		  </div>
-		</div>
-	  </nav>
+  <nav aria-label="Fihenan-dalana">
+    <a class="nav-brand" href="/index-mg">🦇 Ekipa Fanihy</a>
+    <a href="/work-mg"{% if page.title == "Asa" %} class="active"{% endif %}>Asa</a>
+    <a href="/team-mg"{% if page.title == "Ekipa" %} class="active"{% endif %}>Ekipa</a>
+    <a href="/index" aria-label="English version">🇺🇸</a>
+  </nav>
 </header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,18 +1,8 @@
 <header>
-	<nav class="navbar navbar-expand-lg navbar-light bg-light rounded" aria-label="navbar">
-		<div class="container-fluid">
-		  <a class="navbar-brand" href="/">🦇 Ekipa Fanihy</a>
-		  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
-			<span class="navbar-toggler-icon"></span>
-		  </button>
-	
-		  <div class="collapse navbar-collapse" id="navbar">
-			<ul class="navbar-nav me-auto mb-2 mb-md-0">
-			  <li class="nav-item"><a class="nav-link{% if page.title == "Our Work" %} active{% endif %}" href="/work">Our Work</a></li>
-			  <li class="nav-item"><a class="nav-link{% if page.title == "Team" %} active{% endif %}" href="/team">Team</a></li>
-			  <li class="nav-item"><a class="nav-link" href="/index-mg">🇲🇬</a></li>
-			</ul>
-		  </div>
-		</div>
-	  </nav>
+  <nav aria-label="Main navigation">
+    <a class="nav-brand" href="/">🦇 Ekipa Fanihy</a>
+    <a href="/work"{% if page.title == "Our Work" %} class="active"{% endif %}>Our Work</a>
+    <a href="/team"{% if page.title == "Team" %} class="active"{% endif %}>Team</a>
+    <a href="/index-mg" aria-label="Malagasy version">🇲🇬</a>
+  </nav>
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,23 +3,20 @@
 
 {% include head.html %}
 
-<body class="bg-light">
-  <div>
-    <div class="bg-light p-5 rounded">
-      <div class="col-lg-8 mx-auto">
-        {% if page.url contains 'mg' %} 
-          {% include header-mg.html %}
-        {% else %}
-          {% include header.html %}
-        {% endif %}
-        
-        {{ content }}
-        
-        {% include footer.html %}
-      </div>
-    </div>
+<body>
+  <div class="site-wrapper">
+    {% if page.url contains 'mg' %}
+      {% include header-mg.html %}
+    {% else %}
+      {% include header.html %}
+    {% endif %}
+
+    <main>
+      {{ content }}
+    </main>
+
+    {% include footer.html %}
   </div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 </body>
 
 </html>

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,81 +1,248 @@
-a:not(.nav-link):not(.navbar-brand):not(.btn-primary):link {
-   color: #800000;
-   text-decoration: underline;
- }
+/* Ekipa Fanihy — custom styles */
 
- a:not(.nav-link):not(.navbar-brand):not(.btn-primary):visited {
-   color: #800000;
-   text-decoration: underline;
- }
+:root {
+  --color-bg: #faf8f5;
+  --color-text: #1a1a1a;
+  --color-brand: #800000;
+  --color-brand-dark: #26190D;
+  --color-muted: #5a5a5a;
+  --color-border: #d8d4cd;
+  --max-width: 700px;
+  --font-serif: Georgia, 'Times New Roman', serif;
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
 
- a:not(.nav-link):not(.navbar-brand):not(.btn-primary):hover {
-   color: #26190D;
-   text-decoration: none;
- }
+*, *::before, *::after {
+  box-sizing: border-box;
+}
 
- a:not(.nav-link):not(.navbar-brand):not(.btn-primary):active {
-   color: #26190D;
-   text-decoration: none;
- }
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.7;
+}
 
- .btn-primary:link, .btn-primary:visited {
-   background-color: #800000;
-   border-color: #800000;
- }
+/* Layout */
 
- .btn-primary:hover, .btn-primary:active {
-   background-color: #26190D;
-   border-color: #26190D;
- }
+.site-wrapper {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
 
- /*
- .nav-link a:link, .nav-link a:visited {
-   text-decoration: none;
- } */
+/* Navigation */
 
- img {
-   max-width: 100%;
- }
+header {
+  padding: 1.5rem 0 1rem;
+  margin-bottom: 2.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
 
- img.float-start {
-   margin: 1rem 1rem 1rem 0;
- }
+nav {
+  display: flex;
+  align-items: baseline;
+  gap: 1.75rem;
+}
 
- img.float-end {
-   margin: 1rem 0 1rem 1rem;
- }
+.nav-brand {
+  font-family: var(--font-serif);
+  font-size: 1.1rem;
+  color: var(--color-text);
+  text-decoration: none;
+  margin-right: auto;
+}
 
- /* Side notes for calling out things
- https://gist.github.com/matthiasg/6153853
- -------------------------------------------------- */
+.nav-brand:hover {
+  color: var(--color-brand);
+  text-decoration: none;
+}
 
- /* Base styles (regardless of theme) */
- .bs-callout {
-   margin: 20px 0;
-   padding: 15px 30px 15px 15px;
-   border-left: 5px solid #eee;
- }
- .bs-callout h4 {
-   margin-top: 0;
- }
- .bs-callout p:last-child {
-   margin-bottom: 0;
- }
- .bs-callout code,
- .bs-callout .highlight {
-   background-color: #fff;
- }
+nav a {
+  color: var(--color-muted);
+  text-decoration: none;
+  font-size: 0.875rem;
+  letter-spacing: 0.03em;
+}
 
- /* Themes for different contexts */
- .bs-callout-danger {
-   background-color: #fcf2f2;
-   border-color: #dFb5b4;
- }
- .bs-callout-warning {
-   background-color: #fefbed;
-   border-color: #f1e7bc;
- }
- .bs-callout-info {
-   background-color: #f0f7fd;
-   border-color: #d0e3f0;
- }
+nav a:hover {
+  color: var(--color-brand);
+}
+
+nav a.active {
+  color: var(--color-brand);
+  border-bottom: 2px solid var(--color-brand);
+  padding-bottom: 1px;
+}
+
+/* Main content */
+
+main {
+  padding-bottom: 3.5rem;
+}
+
+/* Typography */
+
+h1 {
+  font-family: var(--font-serif);
+  font-weight: normal;
+  font-size: 1.7rem;
+  margin: 0 0 1.5rem;
+  color: var(--color-brand);
+  line-height: 1.3;
+}
+
+h2 {
+  font-family: var(--font-serif);
+  font-weight: normal;
+  font-size: 1.3rem;
+  margin: 2.25rem 0 0.75rem;
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.3rem;
+}
+
+h4, h5 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+p {
+  margin: 0 0 1rem;
+}
+
+/* Links */
+
+a {
+  color: var(--color-brand);
+  text-decoration: underline;
+}
+
+a:hover {
+  color: var(--color-brand-dark);
+  text-decoration: none;
+}
+
+a:visited {
+  color: var(--color-brand);
+}
+
+/* Images */
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+img.float-start {
+  float: left;
+  width: 30%;
+  margin: 0.25rem 1.5rem 1rem 0;
+}
+
+img.float-end {
+  float: right;
+  width: 30%;
+  margin: 0.25rem 0 1rem 1.5rem;
+}
+
+/* Logo on homepage */
+
+.logo-wrap {
+  text-align: center;
+  margin: 2rem 0;
+}
+
+.logo-wrap img {
+  max-width: 300px;
+}
+
+/* Program cards */
+
+.cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  margin: 1.25rem 0 1.75rem;
+}
+
+.card {
+  border: 1px solid var(--color-border);
+  padding: 1.25rem;
+  background: #fff;
+}
+
+.card h5 {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  font-weight: normal;
+  color: var(--color-brand);
+  margin-bottom: 0.6rem;
+}
+
+.card p {
+  font-size: 0.9rem;
+}
+
+/* Buttons */
+
+.btn {
+  display: inline-block;
+  padding: 0.35em 0.85em;
+  background: var(--color-brand);
+  color: #fff;
+  text-decoration: none;
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+}
+
+.btn:hover {
+  background: var(--color-brand-dark);
+  color: #fff;
+  text-decoration: none;
+}
+
+.btn:visited {
+  color: #fff;
+}
+
+/* Callouts */
+
+.callout {
+  margin: 1.25rem 0;
+  padding: 0.75rem 1rem;
+  border-left: 4px solid var(--color-border);
+  background: #f5f3f0;
+}
+
+.callout-info {
+  border-color: #7aabe0;
+  background: #f0f7fd;
+}
+
+/* Footer */
+
+footer {
+  border-top: 1px solid var(--color-border);
+  padding: 1.5rem 0;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+/* Responsive */
+
+@media (max-width: 560px) {
+  img.float-start,
+  img.float-end {
+    float: none;
+    width: 100%;
+    margin: 0.75rem 0;
+  }
+
+  .cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -14,9 +14,9 @@ We are a non-profit organization based in Antananarivo, Madagascar, dedicated to
 
 Association Ekipa Fanihy was formally incorporated in November 2022, though the team of biologists has been working together informally since 2013, when its founders, Association Director Dr. Hafaliana Christian Ranaivoson and Scientific Advisor Dr. Cara Brook, began their collaborative PhD studies on pathogen ecology and population dynamics in Malagasy fruit bats. Association Ekipa Fanihy aims to carry on the spirit of their original collaboration by establishing a supportive environment and physical infrastructure for the exchange of knowledge between local and foreign researchers.
 
-<center>
-<img src="/assets/team/EkipaFanihyLogoWhite.png" alt="bat" class="img-fluid" />
-</center>
+<div class="logo-wrap">
+<img src="/assets/team/EkipaFanihyLogoWhite.png" alt="Ekipa Fanihy logo" />
+</div>
 
 <!--
 <img src="/assets/Ekipa_camp.jpg" class="img-fluid" />

--- a/team.md
+++ b/team.md
@@ -5,7 +5,7 @@ permalink: /team
 ---
 ## New Members
 
-<img src="/assets/team/Hands together.JPG" alt="hands" class="img-thumbnail float-end col-sm-3">
+<img src="/assets/team/Hands together.JPG" alt="hands" class="float-end">
 
 We are constantly on the lookout for new members to fill a variety of roles on our team. 
 
@@ -25,7 +25,7 @@ Association Ekipa Fanihy recruits and trains one new Master's student per year f
 
 ## Current Members
 	
-<img src="/assets/team/christian_ranaivoson.jpg" alt="christian" class="img-thumbnail float-start col-md-3" />
+<img src="/assets/team/christian_ranaivoson.jpg" alt="christian" class="float-start" />
 
 Dr. **RANAIVOSON Hafaliana Christian** is the Director of Association Ekipa Fanihy. Contact: [christian.ranaivoson@ekipafanihy.org](mailto:christian.ranaivoson@ekipafanihy.org).
 
@@ -33,7 +33,7 @@ Currently a Postdoctoral Scholar in the Brook lab in Department of Ecology and E
 
 <div style="clear:both;">&nbsp;</div>
 
-<img src="/assets/team/angelo_andrianiaina.jpg" alt="angelo" class="img-thumbnail float-start col-md-3" />
+<img src="/assets/team/angelo_andrianiaina.jpg" alt="angelo" class="float-start" />
 
 **ANDRIANIAINA Angelo** is a Research Technician at Association Ekipa Fanihy. Contact: [angelo.andrianiaina@ekipafanihy.org](mailto:angelo.andrianiaina@ekipafanihy.org).
 
@@ -41,7 +41,7 @@ Angelo is a PhD student in the Department of Zoology and Animal Biodiversity at 
 
 <div style="clear:both;">&nbsp;</div>
 
-<img src="/assets/team/santino_andry.jpg" alt="santino" class="img-thumbnail float-start col-md-3" />
+<img src="/assets/team/santino_andry.jpg" alt="santino" class="float-start" />
 
 **ANDRY Santino** is a Research Technician at Association Ekipa Fanihy. Contact: [santino.andry@ekipafanihy.org](mailto:santino.andry@ekipafanihy.org).
 
@@ -56,7 +56,7 @@ Biography coming soon!
 <div style="clear:both;">&nbsp;</div>
 
 
-<img src="/assets/team/rova_indrianala_ratsimamanga .jpg" alt="rova" class="img-thumbnail float-start col-md-3" />
+<img src="/assets/team/rova_indrianala_ratsimamanga .jpg" alt="rova" class="float-start" />
 
 **RATSIMAMANGA Rova Indrianala** is a **Master's Student** with Association Ekipa Fanihy.
 
@@ -64,7 +64,7 @@ Rova is currently pursuing a Master's degree in the Department of Zoology and An
 
 <div style="clear:both;">&nbsp;</div>
 
-<img src="/assets/team/carabrook-headshot-2020.jpeg" alt="headshot" class="img-thumbnail float-start col-md-3" />
+<img src="/assets/team/carabrook-headshot-2020.jpeg" alt="headshot" class="float-start" />
 
 Dr. **BROOK Cara** is the Scientific Advisor to Ekipa Fanihy. Contact: [cara.brook@ekipafanihy.org](mailto:cara.brook@ekipafanihy.org).
 
@@ -72,7 +72,7 @@ Cara is an Assistant Professor in the [Department of Ecology and Evolution](http
 
 <div style="clear:both;">&nbsp;</div>
 
-<img src="/assets/team/katherine_mcferrin.jpg" alt="katherine" class="img-thumbnail float-start col-md-3" />
+<img src="/assets/team/katherine_mcferrin.jpg" alt="katherine" class="float-start" />
 
 **MCFERRIN Katherine** is a volunteer Field Project Manager with Association Ekipa Fanihy. Contact: [katherine.mcferrin@ekipafanihy.org](mailto:katherine.mcferrin@ekipafanihy.org).
 
@@ -81,7 +81,7 @@ Katherine co-leads monthly field expeditions to capture and sample Madagascar en
 
 <div style="clear:both;">&nbsp;</div>
 
-<img src="/assets/team/martin-roland.jpg" alt="martin" class="img-thumbnail float-start col-md-3" />
+<img src="/assets/team/martin-roland.jpg" alt="martin" class="float-start" />
 
 **ROLAND Martin**  is a volunteer Field Project Manager with Association Ekipa Fanihy. Contact: [martin.roland@ekipafanihy.org](mailto:martin.roland@ekipafanihy.org).
 

--- a/work.md
+++ b/work.md
@@ -5,44 +5,35 @@ permalink: /work
 ---
 ## Research
 
-<img src="/assets/research/lab_tent.jpeg" alt="tent" class="img-thumbnail float-end col-md-5" />
+<img src="/assets/research/lab_tent.jpeg" alt="tent" class="float-end" />
 
 The research of Association Ekipa Fanihy focuses on the disease ecology and population dynamics of three endemic species of threatened fruit bats in Madagascar:  *Pteropus rufus, Eidolon dupreanum,* and *Rousettus madagascariensis*. Bats (order Chiroptera) are divided into two major suborders, Yangochiroptera and Yinpterochiroptera, the latter of which contains the Old World Fruit Bat family, Pteropodidae, and includes our three Malagasy species. Bats are known reservoirs for several highly virulent emerging human viruses but, themselves, experience limited clinical pathology from infection. Our research, in collaboration with the [Brook lab at the University of Chicago](https://brooklab.org), aims to uncover how viruses circulate in wild bat populations in Madagascar and attempts to demonstrate how bat conservation can be leveraged to promote human public health. Based on work carried out in other bat-virus systems globally (e.g. [Australia](https://www.nature.com/articles/s41586-022-05506-2)), we hypothesize that healthy bats in intact ecosystems shed less virus into their surrounding ecosystems, posing a reduced public health threat.
 
-Day-to-day, Association Ekipa Fanihy conducts field studies, molecular analysis of biological samples in the lab, quantitative data analysis on our computers, and strives to publish our findings in scientific research journals. 
+Day-to-day, Association Ekipa Fanihy conducts field studies, molecular analysis of biological samples in the lab, quantitative data analysis on our computers, and strives to publish our findings in scientific research journals.
 
-<div style="clear:both;">&nbsp;</div>
+<div style="clear:both;"></div>
 
 ## Outreach and Teaching
 
 In collaboration with the [Brook lab at the University of Chicago](https://brooklab.org), we host one data analysis course and one one-on-one scientific mentoring program each year for Malagasy biology students at the graduate level.
 
-
-<div class="row">
-  <div class="col-sm-6">
-    <div class="card">
-      <div class="card-body">
-       <h5 class="card-title">E<sup>2</sup>M<sup>2</sup></h5>
-        <p class="card-text">An introduction to R and workshop introducing the use of dynamical models in understanding ecological and epidemiological data.</p>
-        <p><em>Will be accepting applications for the upcoming March workshop in January 2024!</em></p>
-        <a href="https://e2m2.org/" class="btn btn-primary">Learn more</a>
-      </div>
-    </div>
+<div class="cards">
+  <div class="card">
+    <h5>E<sup>2</sup>M<sup>2</sup></h5>
+    <p>An introduction to R and workshop introducing the use of dynamical models in understanding ecological and epidemiological data.</p>
+    <p><em>Will be accepting applications for the upcoming March workshop in January 2024!</em></p>
+    <a href="https://e2m2.org/" class="btn">Learn more</a>
   </div>
-  <div class="col-sm-6">
-    <div class="card">
-      <div class="card-body">
-        <h5 class="card-title">Coding 4 Conservation</h5>
-        <p class="card-text">A year-long mentorship program in R-based data analysis and communication for Malagasy students with ongoing research projects in ecology, conservation, biodiversity science, and related fields which runs from May 2022 to April 2023.</p>
-        <p><em>Currently in progress!</em></p>
-        <a href="https://coding4conservation.org/" class="btn btn-primary">Learn more</a>
-      </div>
-    </div>
+  <div class="card">
+    <h5>Coding 4 Conservation</h5>
+    <p>A year-long mentorship program in R-based data analysis and communication for Malagasy students with ongoing research projects in ecology, conservation, biodiversity science, and related fields which runs from May 2022 to April 2023.</p>
+    <p><em>Currently in progress!</em></p>
+    <a href="https://coding4conservation.org/" class="btn">Learn more</a>
   </div>
 </div>
 
 ## Applied Conservation
 
-<img src="/assets/research/Analambotaka roost.jpeg" alt="bat" class="img-thumbnail float-start col-md-5" />
+<img src="/assets/research/Analambotaka roost.jpeg" alt="bat" class="float-start" />
 
-In addition to scientific research and education, Association Ekipa Fanihy also aspires to carry out applied, real-world conservation. We are currently working in collaboration with [**Madigasikara Voakajy**](https://www.madagasikara-voakajy.org/), a Malagasy conservation NGO, to document population declines and quantify valuable ecosystem service contributions for threatened fruit bats across Madagascar. Fruit bats play a critical role in the regeneration of native forests in Madagascar through their roles as seed dispersers and pollinators. As one example, *Eidolon dupreanum* is the only known extant pollinator of the endemic, endangered Malagasy baobab, *Adansonia suarezensis*. Our [prior conservation research](https://doi.org/10.1016/j.biocon.2019.03.032) suggests that the Madagascar Flying Fox, *Pteropus rufus*, is particularly threatened by habitat destruction and human hunting for food consumption in Madagascar. As a result, one of Association Ekipa Fanihy’s specific goals is habitat protection for *P. rufus*. Currently, we are working to protect the forest in Analambotaka, one of our field sites, which is home to a large (>1000) *P. rufus* roost. This area and much of the surrounding forest are cut and burned each year for cattle grazing, as is commonly practiced in Madagascar. Association Ekipa Fanihy is currently working with the local fokontany and commune to create a VOI-protected area. We also plan to improve bridges and roads leading to and from the Analambotaka area to give thanks to the local community for their conservation contributions. 
+In addition to scientific research and education, Association Ekipa Fanihy also aspires to carry out applied, real-world conservation. We are currently working in collaboration with [**Madigasikara Voakajy**](https://www.madagasikara-voakajy.org/), a Malagasy conservation NGO, to document population declines and quantify valuable ecosystem service contributions for threatened fruit bats across Madagascar. Fruit bats play a critical role in the regeneration of native forests in Madagascar through their roles as seed dispersers and pollinators. As one example, *Eidolon dupreanum* is the only known extant pollinator of the endemic, endangered Malagasy baobab, *Adansonia suarezensis*. Our [prior conservation research](https://doi.org/10.1016/j.biocon.2019.03.032) suggests that the Madagascar Flying Fox, *Pteropus rufus*, is particularly threatened by habitat destruction and human hunting for food consumption in Madagascar. As a result, one of Association Ekipa Fanihy's specific goals is habitat protection for *P. rufus*. Currently, we are working to protect the forest in Analambotaka, one of our field sites, which is home to a large (>1000) *P. rufus* roost. This area and much of the surrounding forest are cut and burned each year for cattle grazing, as is commonly practiced in Madagascar. Association Ekipa Fanihy is currently working with the local fokontany and commune to create a VOI-protected area. We also plan to improve bridges and roads leading to and from the Analambotaka area to give thanks to the local community for their conservation contributions.


### PR DESCRIPTION
Replace Bootstrap 5 CDN dependency (~150KB) with ~220 lines of purpose-built CSS. Clean up layouts and all content pages of Bootstrap utility classes.

- New style.css: custom CSS variables, serif headings, warm off-white background (#faf8f5), maroon brand color (#800000), responsive grid for cards, float helpers for images, simple nav with underline active state
- Remove Bootstrap CDN links from head.html and default.html JS bundle
- Simplify default.html and both header includes to plain semantic HTML
- Simplify footer.html
- work.md: replace .card/.card-body/.row/.col-sm-6/.btn-primary markup with .cards/.card/.btn, strip img-thumbnail and col-md-5 from images
- team.md: strip img-thumbnail and col-md-3/col-sm-3 from all team photos
- index.md: replace deprecated <center> with .logo-wrap div

https://claude.ai/code/session_01RUb9bBPMQ2rtyAcwg5GaLt