### PR TITLE
Update Brook Lab affiliation from UChicago to UC Berkeley

### DIFF
--- a/team-mg.md
+++ b/team-mg.md
@@ -13,7 +13,7 @@ Singanina manokana amin'ny izany ireto olona voasokajy manaraka ireto:
 - Ny mpianatra Master
 - Ny Manomana DOctorat
 - Ny teknisianina
-- Ny mpilatsaka antsitrapo avy any ivelany (izay avy ao amin'ny [Brook lab Oniversite ny Chicago](https://brooklab.org/join))
+- Ny mpilatsaka antsitrapo avy any ivelany (izay avy ao amin'ny [Brook lab Oniversite Kalifornia Berkeley](https://brooklab.org/join))
 
 Ny tolotr'asa rehetra dia aparitaka amin'ny aterineto ankoatran'ny filatsahana antsitrapo. Ka raha tafiditra amin'ny ireo sokajy voalaza etsy ambony ianao sy liana amin'ny asa fikarohana manodidina ny tontolon'ny fanihy eto Madagasikara dia  aza misalasala mandefa mailaka : [team@ekipafanihy.org](mailto:team@ekipafanihy.org).
 
@@ -27,7 +27,7 @@ Ny Ekipa Fanihy dia mampiofana sy mandray antanana mpianatra manomana Matser ira
 
 RANAIVOSON Hafaliana Christian no mpitarikan'ny fikambanana Ekipa Fanihy. Fifandraisana: [christian.ranaivoson@ekipafanihy.org](mailto:christian.ranaivoson@ekipafanihy.org).
 
-Manatanterakan'ny dingana aorianan'ny docotrat (Postdoctoral) ao amin'ny Brook Lab izay anatin'ny departemantan'ny "Ecology and Evolution" Oniversite ny Chicago ankehitriny. Izy dia mitarika ny asa Next Generation Sequencing (NGS)izay itilianan'ny viriosy ita amin'ny fanihy. Izy dia niasa tao amin'ny Institut Pasteur de Mdagascar tamin'ny maha enjeniera mpikaroka tao amin'ny sampana virolojia. Christian dia nahazo ny diploma Master sy PhD tao aminy departemantan'ny "Zoology and Animal Biodiversity" Oniversite ny Antananarivo, izay niompana tamin'ny fifindrafindrana sy toerana ahitanan'ny parazita "erythrocytic" ny fanihy, indrindra fa ny *Babesia* spp. ny fanihy be *Pteropus rufus*. Izy ihany koa dia efa nanao fikarohana momban'ny aretina mpahazo ny fozaorana sy kakana ita amin'ny biby mangatsia-drà. 
+Manatanterakan'ny dingana aorianan'ny docotrat (Postdoctoral) ao amin'ny Brook Lab izay anatin'ny departemantan'ny "Integrative Biology" Oniversite Kalifornia Berkeley ankehitriny. Izy dia mitarika ny asa Next Generation Sequencing (NGS)izay itilianan'ny viriosy ita amin'ny fanihy. Izy dia niasa tao amin'ny Institut Pasteur de Mdagascar tamin'ny maha enjeniera mpikaroka tao amin'ny sampana virolojia. Christian dia nahazo ny diploma Master sy PhD tao aminy departemantan'ny "Zoology and Animal Biodiversity" Oniversite ny Antananarivo, izay niompana tamin'ny fifindrafindrana sy toerana ahitanan'ny parazita "erythrocytic" ny fanihy, indrindra fa ny *Babesia* spp. ny fanihy be *Pteropus rufus*. Izy ihany koa dia efa nanao fikarohana momban'ny aretina mpahazo ny fozaorana sy kakana ita amin'ny biby mangatsia-drà. 
 
 <div style="clear:both;">&nbsp;</div>
 
@@ -64,7 +64,7 @@ Izy dia manomana Master ao amin'ny Departemantan'ny "Zoology and Animal Biodiver
 
 Dr. BROOK Cara dia mpanolotsaina siantifikan'ny Ekipa Fanihy. Fifandraisana : [cara.brook@ekipafanihy.org](mailto:cara.brook@ekipafanihy.org).
 
-Izy dia "Assistant Professor" ao amin'ny "[Department of Ecology and Evolution](https://ecologyandevolution.uchicago.edu/) ao amin'ny Oniversite ny Chicago. Ny [Brook Lab](https://www.brooklab.org) dia manadihady ny Ekolojia sy dinamikan'ny fivoaran'ny aretimifindran'ny biby, indrindra izay fantatra fa tahirizin'ny fanihy. I Cara dia nametraka fanamby hamakafaka lalina ny fikarohana izay ataony, hampiroborobo ny tontolon'ny siansa ary ny fahaiza-manao eto Madagasikara. Nahazo ny Doctorat amin'ny "Ecology and Evolutionnary Biology" tao amin'ny Oniversite ny Princeton  ny taona 2017 sy diploma amin'ny "Earth Systems tao amin'ny Oniversite ny Stanford ny taona 2010 izy.
+Izy dia "Assistant Professor" ao amin'ny "[Department of Integrative Biology](https://ib.berkeley.edu/) ao amin'ny Oniversite Kalifornia Berkeley. Ny [Brook Lab](https://www.brooklab.org) dia manadihady ny Ekolojia sy dinamikan'ny fivoaran'ny aretimifindran'ny biby, indrindra izay fantatra fa tahirizin'ny fanihy. I Cara dia nametraka fanamby hamakafaka lalina ny fikarohana izay ataony, hampiroborobo ny tontolon'ny siansa ary ny fahaiza-manao eto Madagasikara. Nahazo ny Doctorat amin'ny "Ecology and Evolutionnary Biology" tao amin'ny Oniversite ny Princeton  ny taona 2017 sy diploma amin'ny "Earth Systems tao amin'ny Oniversite ny Stanford ny taona 2010 izy.
 
 <div style="clear:both;">&nbsp;</div>
 

--- a/team.md
+++ b/team.md
@@ -13,7 +13,7 @@ In particular, we regularly support the training of new members in the following
 - Master's students 
 - PhD students 
 - Laboratory or field technicians 
-- Foreign volunteers (recruited twice annually via the [Brook Lab](https://brooklab.org/join) at UChicago).
+- Foreign volunteers (recruited twice annually via the [Brook Lab](https://brooklab.org/join) at UC Berkeley).
 
 With the exception of foreign volunteers, positions will be posted here as they become available. In the meantime, if you are interested in any of these roles, please reach out to our team's general contact at [team@ekipafanihy.org](mailto:team@ekipafanihy.org). 
 
@@ -29,7 +29,7 @@ Association Ekipa Fanihy recruits and trains one new Master's student per year f
 
 Dr. **RANAIVOSON Hafaliana Christian** is the Director of Association Ekipa Fanihy. Contact: [christian.ranaivoson@ekipafanihy.org](mailto:christian.ranaivoson@ekipafanihy.org).
 
-Currently a Postdoctoral Scholar in the Brook lab in Department of Ecology and Evolution at the University of Chicago, Christian leads Next Generation Sequencing (NGS) studies targeting viral discovery in Malagasy fruit bats. Previously, he worked as a Research Engineer in the Virology Unit at Institut Pasteur de Madagascar, where he conducted SARS-CoV-2 genomic surveillance in Madagascar. Christian received his Masters and PhD degrees from the Department of Zoology and Animal Biodiversity at the University of Antananarivo, Madagascar where his research focused on the distribution and transmission of intra-erythrocytic parasites of Malagasy fruit bats, specifically *Babesia* spp. infections of the Madagascar flying fox, *Pteropus rufus*. Dr. Ranaivoson has also previously studied infections of Malagasy crayfishes and nematode parasites of Malagasy reptiles.
+Currently a Postdoctoral Scholar in the Brook lab in the Department of Integrative Biology at UC Berkeley, Christian leads Next Generation Sequencing (NGS) studies targeting viral discovery in Malagasy fruit bats. Previously, he worked as a Research Engineer in the Virology Unit at Institut Pasteur de Madagascar, where he conducted SARS-CoV-2 genomic surveillance in Madagascar. Christian received his Masters and PhD degrees from the Department of Zoology and Animal Biodiversity at the University of Antananarivo, Madagascar where his research focused on the distribution and transmission of intra-erythrocytic parasites of Malagasy fruit bats, specifically *Babesia* spp. infections of the Madagascar flying fox, *Pteropus rufus*. Dr. Ranaivoson has also previously studied infections of Malagasy crayfishes and nematode parasites of Malagasy reptiles.
 
 <div style="clear:both;">&nbsp;</div>
 
@@ -68,7 +68,7 @@ Rova is currently pursuing a Master's degree in the Department of Zoology and An
 
 Dr. **BROOK Cara** is the Scientific Advisor to Ekipa Fanihy. Contact: [cara.brook@ekipafanihy.org](mailto:cara.brook@ekipafanihy.org).
 
-Cara is an Assistant Professor in the [Department of Ecology and Evolution](https://ecologyandevolution.uchicago.edu/) at the University of Chicago. The [Brook Lab](https://brooklab.org) investigates the ecological and evolutionary dynamics of zoonotic infections, in particular those derived from wild bat hosts. Cara is committed to conducting rigorous science while simultaneously promoting scientific development, education, and capacity building in Madagascar. She received her PhD in Ecology and Evolutionary Biology from Princeton University in 2017 and her BS in Earth Systems from Stanford University in 2010. 
+Cara is an Assistant Professor in the [Department of Integrative Biology](https://ib.berkeley.edu/) at UC Berkeley. The [Brook Lab](https://brooklab.org) investigates the ecological and evolutionary dynamics of zoonotic infections, in particular those derived from wild bat hosts. Cara is committed to conducting rigorous science while simultaneously promoting scientific development, education, and capacity building in Madagascar. She received her PhD in Ecology and Evolutionary Biology from Princeton University in 2017 and her BS in Earth Systems from Stanford University in 2010. 
 
 <div style="clear:both;">&nbsp;</div>
 

--- a/work-mg.md
+++ b/work-mg.md
@@ -9,7 +9,7 @@ permalink: /work-mg
 
 Ny fikarohana ataon'ny ekipa Fanihy dia miompana amin'ny tontolon'ny aretina sy ny dinamikan'ny fanihy telo karazany eto Madagasikara: *Pteropus rufus*, *Eidolon dupreanum*, ary ny *Rousettus madagascariensis*.
 
-Ny fanihy(sokajy Chiroptera) dia mizara ho zanatsokajy, Yangochiroptera sy Yinpterochiroptera, ito farany dia ahitana ny fanihy mihinana voankazo, Pteropodidae izay misy ny fanihy malagasy telo karazany. Ny fanihy dia fantatra fa mpitahiry otrikaretina maro izay mety miparitaka sy mankarary ny olombelona nefa kosa izy ireo dia tsy ahitana soritraretina. Ny asa fikarohana atao miaraka amin'ny [Brook lab Oniversite ny Chicago](https://brooklab.org) dia mamakafaka ny hoe ahoana ny fivezivezen'ny viriosy eo amin'ny mponin'ny fanihy eto Madagasikara sy hanamarina fa ny fiarovana ny fanihy dia mety entina hanatsaranan'ny fahasalamambahoaka. Raha ny asa mahakasika ny viriosy ita amin'ny fanihy izay natao tany [Australia](https://www.nature.com/articles/s41586-022-05506-2) dia namoaka petra-kevitra izahay hoe ny fanihy salama sy voa-aro dia mitazona kokoa ny viriosy tsy hiparitaka.
+Ny fanihy(sokajy Chiroptera) dia mizara ho zanatsokajy, Yangochiroptera sy Yinpterochiroptera, ito farany dia ahitana ny fanihy mihinana voankazo, Pteropodidae izay misy ny fanihy malagasy telo karazany. Ny fanihy dia fantatra fa mpitahiry otrikaretina maro izay mety miparitaka sy mankarary ny olombelona nefa kosa izy ireo dia tsy ahitana soritraretina. Ny asa fikarohana atao miaraka amin'ny [Brook lab Oniversite Kalifornia Berkeley](https://brooklab.org) dia mamakafaka ny hoe ahoana ny fivezivezen'ny viriosy eo amin'ny mponin'ny fanihy eto Madagasikara sy hanamarina fa ny fiarovana ny fanihy dia mety entina hanatsaranan'ny fahasalamambahoaka. Raha ny asa mahakasika ny viriosy ita amin'ny fanihy izay natao tany [Australia](https://www.nature.com/articles/s41586-022-05506-2) dia namoaka petra-kevitra izahay hoe ny fanihy salama sy voa-aro dia mitazona kokoa ny viriosy tsy hiparitaka.
 
 Ny fikambanana Ekipa Fanihy dia midina ifotony mandavantaona maka singa avy amin'ireo fanihy, mitily ireo singa azo anaty laboratoara ary manao fampahafantarana ny vokampikarohana eo aminy sehatra nationaly sy iraisam-pirenena.
 
@@ -17,7 +17,7 @@ Ny fikambanana Ekipa Fanihy dia midina ifotony mandavantaona maka singa avy amin
 
 ## Fampahalalana sy fampianarana
 
-Izahay dia mikarakara atrikasa sy manome fiofanana ho an'ny mpikaroka Malagasy, indray mandeha isantaona izay tafiditra ao anatin'ny fiarahamiasa miaraka amin'ny [Brook lab Oniversite ny Chicago](https://brooklab.org).
+Izahay dia mikarakara atrikasa sy manome fiofanana ho an'ny mpikaroka Malagasy, indray mandeha isantaona izay tafiditra ao anatin'ny fiarahamiasa miaraka amin'ny [Brook lab Oniversite Kalifornia Berkeley](https://brooklab.org).
 
 <div class="row">
   <div class="col-sm-6">

--- a/work.md
+++ b/work.md
@@ -7,7 +7,7 @@ permalink: /work
 
 <img src="/assets/research/lab_tent.jpeg" alt="tent" class="float-end" />
 
-The research of Association Ekipa Fanihy focuses on the disease ecology and population dynamics of three endemic species of threatened fruit bats in Madagascar:  *Pteropus rufus, Eidolon dupreanum,* and *Rousettus madagascariensis*. Bats (order Chiroptera) are divided into two major suborders, Yangochiroptera and Yinpterochiroptera, the latter of which contains the Old World Fruit Bat family, Pteropodidae, and includes our three Malagasy species. Bats are known reservoirs for several highly virulent emerging human viruses but, themselves, experience limited clinical pathology from infection. Our research, in collaboration with the [Brook lab at the University of Chicago](https://brooklab.org), aims to uncover how viruses circulate in wild bat populations in Madagascar and attempts to demonstrate how bat conservation can be leveraged to promote human public health. Based on work carried out in other bat-virus systems globally (e.g. [Australia](https://www.nature.com/articles/s41586-022-05506-2)), we hypothesize that healthy bats in intact ecosystems shed less virus into their surrounding ecosystems, posing a reduced public health threat.
+The research of Association Ekipa Fanihy focuses on the disease ecology and population dynamics of three endemic species of threatened fruit bats in Madagascar:  *Pteropus rufus, Eidolon dupreanum,* and *Rousettus madagascariensis*. Bats (order Chiroptera) are divided into two major suborders, Yangochiroptera and Yinpterochiroptera, the latter of which contains the Old World Fruit Bat family, Pteropodidae, and includes our three Malagasy species. Bats are known reservoirs for several highly virulent emerging human viruses but, themselves, experience limited clinical pathology from infection. Our research, in collaboration with the [Brook lab at UC Berkeley](https://brooklab.org), aims to uncover how viruses circulate in wild bat populations in Madagascar and attempts to demonstrate how bat conservation can be leveraged to promote human public health. Based on work carried out in other bat-virus systems globally (e.g. [Australia](https://www.nature.com/articles/s41586-022-05506-2)), we hypothesize that healthy bats in intact ecosystems shed less virus into their surrounding ecosystems, posing a reduced public health threat.
 
 Day-to-day, Association Ekipa Fanihy conducts field studies, molecular analysis of biological samples in the lab, quantitative data analysis on our computers, and strives to publish our findings in scientific research journals.
 
@@ -15,7 +15,7 @@ Day-to-day, Association Ekipa Fanihy conducts field studies, molecular analysis 
 
 ## Outreach and Teaching
 
-In collaboration with the [Brook lab at the University of Chicago](https://brooklab.org), we host one data analysis course and one one-on-one scientific mentoring program each year for Malagasy biology students at the graduate level.
+In collaboration with the [Brook lab at UC Berkeley](https://brooklab.org), we host one data analysis course and one one-on-one scientific mentoring program each year for Malagasy biology students at the graduate level.
 
 <div class="cards">
   <div class="card">


### PR DESCRIPTION
## Summary
This PR updates all references to the Brook Lab's institutional affiliation from the University of Chicago to UC Berkeley, reflecting the lab's relocation.

## Key Changes
- Updated Brook Lab affiliation from "University of Chicago" / "UChicago" to "UC Berkeley" across all team and work documentation
- Changed department affiliation from "Department of Ecology and Evolution" to "Department of Integrative Biology"
- Updated department links to point to UC Berkeley's Integrative Biology department (ib.berkeley.edu)
- Updated references in both English and Malagasy versions of the documentation:
  - `team.md` and `team-mg.md` (team member descriptions)
  - `work.md` and `work-mg.md` (research and outreach descriptions)

## Files Modified
- team.md
- team-mg.md
- work.md
- work-mg.md

All changes maintain consistency across both language versions and ensure accurate institutional attribution for Dr. Cara Brook and the Brook Lab's current location.

https://claude.ai/code/session_01VD9Nmky5grdZjykCbMPvRD