### PR TITLE
Remove Katherine McFerrin and Martin Roland from team pages

### DIFF
--- a/team-mg.md
+++ b/team-mg.md
@@ -68,20 +68,3 @@ Izy dia "Assistant Professor" ao amin'ny "[Department of Ecology and Evolution](
 
 <div style="clear:both;">&nbsp;</div>
 
-
-<img src="/assets/team/katherine_mcferrin.jpg" alt="katherine" class="img-thumbnail float-start col-md-3" />
-
-
-**MCFERRIN Katherine** dia mpilatsaka antsitrapo ao amin'ny Ekipa Fanihy. Fifandraisana:  [katherine.mcferrin@ekipafanihy.org](mailto:katherine.mcferrin@ekipafanihy.org).
-
-
-Katherine dia isan'ireo mpitarika ny fidinana ifotony izay anatanterahana ny fijerevana ireo fanihy sy fakana singa amin'izy ireo. Nanaraka lalam-piofanana biolijia sy "bioinformatics" tao amin'ny Carleton College izy ary manana ny mari-pahaizana "Bachelor of Arts". Izy dia Efa nanatanteraka fanarahamaso ny "hantavirus" amin'ny biby mpikiky tany Washington antsinana izay niarahany tamin'ny laboratoara "Molecular Ecology of Zoonotic and Animal Pathogens"ao amin'ny Washington State University.Izy ihany koa, dia efa nisehatra tamin'ny fiarovana ny bibidia sy ny politika ekolojika tany Oganda izay nanatanterahany ny fanarahamaso ny voary sy ny fiainan'ny mponina manodidina mba ahafantarana lanindalina kokoa ny fifandraisna'izy roa ireo.
-
-
-<div style="clear:both;">&nbsp;</div>
-
-<img src="/assets/team/martin-roland.jpg" alt="martin" class="img-thumbnail float-start col-md-3" />
-
-**ROLAND Martin** dia mpilatsaka antsitrapo ao amin'ny Ekipa Fanihy. Fifandraisana:  [martin.roland@ekipafanihy.org](mailto:martin.roland@ekipafanihy.org).
-
-Martin dia isan'ireo mpitarika ny fidinana ifotony izay anatanterahana ny fijerevana ireo fanihy sy fakana singa amin'izy ireo. Izy dia manana mari-pahaizana "Bachelor of Arts" tao amin'ny Oniversite an'ny Chicago tamin'ny lalam-piofanana "Environmental Studies and a Minor in Biological Sciences", izay niompana tamin'ny fandalinana ny endrika ivelan'ny voalavo mba afahana mamantatra ny karazany. Izy ihany koa, dia efa nitarika mpianatra: nanatanteraka fakana santionany amin'ireo biby kely miaina anaty rano tany Arizona,namandrika biby mpikiky tany Afovoany andrefan'ny Etazonia, ary nanaramaso ny abetsaky ny ahidrano tany Cape cod.

--- a/team.md
+++ b/team.md
@@ -72,17 +72,3 @@ Cara is an Assistant Professor in the [Department of Ecology and Evolution](http
 
 <div style="clear:both;">&nbsp;</div>
 
-<img src="/assets/team/katherine_mcferrin.jpg" alt="katherine" class="float-start" />
-
-**MCFERRIN Katherine** is a volunteer Field Project Manager with Association Ekipa Fanihy. Contact: [katherine.mcferrin@ekipafanihy.org](mailto:katherine.mcferrin@ekipafanihy.org).
-
-Katherine co-leads monthly field expeditions to capture and sample Madagascar endemic fruit bats. Katherine earned her B.A. in Biology from Carleton College where she focused on organismal biology and bioinformatics. She has previously conducted hantavirus surveillance in wild rodents in eastern Washington with the Molecular Ecology of Zoonotic and Animal Pathogens Lab at Washington State University. Additionally, she studied wildlife conservation and political ecology in Uganda where she conducted ecological surveys and used social science methods to better understand human-wildlife interactions. 
-
-
-<div style="clear:both;">&nbsp;</div>
-
-<img src="/assets/team/martin-roland.jpg" alt="martin" class="float-start" />
-
-**ROLAND Martin**  is a volunteer Field Project Manager with Association Ekipa Fanihy. Contact: [martin.roland@ekipafanihy.org](mailto:martin.roland@ekipafanihy.org).
-
-Martin co-leads monthly field expeditions to capture and sample Madagascar endemic fruit bats. He graduated from the University of Chicago with a B.A. in Environmental Studies and a Minor in Biological Sciences, where he engaged in research focused on the morphological study of field mice for species identification. As a field TA he has led student groups on rigorous field projects including sampling for aquatic insect diversity in the mountains of Arizona, trapping rodents in the Midwest, and surveying intertidal algae abundance in Cape Cod.


### PR DESCRIPTION
## Summary
This PR removes the team member profiles for Katherine McFerrin and Martin Roland from both the English and Malagasy team pages.

## Changes Made
- Removed Katherine McFerrin's profile section from `team.md` (English version)
- Removed Martin Roland's profile section from `team.md` (English version)
- Removed Katherine McFerrin's profile section from `team-mg.md` (Malagasy translation)
- Removed Martin Roland's profile section from `team-mg.md` (Malagasy translation)

## Details
Both team members' profiles, including their photos, contact information, and biographical descriptions, have been completely removed from both language versions of the team page. This appears to be a personnel update reflecting changes in the team composition.

https://claude.ai/code/session_01WzJHkDu4gE35QnCwKq8XN6