### PR TITLE
Add CLAUDE.md documentation for Ekipa Fanihy website

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md — Ekipa Fanihy Website
+
+## Overview
+
+This is the [Ekipa Fanihy](https://ekipafanihy.org) website — a Jekyll static site deployed via Netlify. It shares the same base structure as the [Brook Lab website](https://brooklab.org) ([brooklabteam/www](https://github.com/brooklabteam/www)).
+
+**Refer to [brooklabteam/www CLAUDE.md](https://github.com/brooklabteam/www/blob/main/CLAUDE.md) for full documentation** on local development, repository structure, adding news posts, top-level pages, navigation, site configuration, and deployment — the conventions are the same.
+
+## Ekipa Fanihy–Specific Notes
+
+### Bilingual Content
+
+Many pages have both English and Malagasy versions:
+
+| English file | Malagasy file | Notes |
+|---|---|---|
+| `index.md` | `index-mg.md` | Home page |
+| `team.md` | `team-mg.md` | Team page |
+| `work.md` | `work-mg.md` | Work/research page |
+
+### Site Configuration
+
+`_config.yml` points to `https://ekipafanihy.org`. Update this file if the site URL changes.


### PR DESCRIPTION
## Summary
Added comprehensive documentation file (`CLAUDE.md`) for the Ekipa Fanihy website project, providing developers with setup and maintenance guidance.

## Changes
- Created `CLAUDE.md` with project overview and references to the base Brook Lab website documentation
- Documented bilingual content structure (English and Malagasy versions) with a reference table for key pages
- Added site-specific configuration notes regarding the `_config.yml` file and domain settings

## Details
The documentation follows the same structure as the [Brook Lab website repository](https://github.com/brooklabteam/www) since Ekipa Fanihy shares the same Jekyll-based architecture. Rather than duplicating full documentation, `CLAUDE.md` points developers to the Brook Lab repository for comprehensive guidance on local development, repository structure, and deployment procedures, while highlighting Ekipa Fanihy–specific considerations around bilingual content management and site configuration.

https://claude.ai/code/session_019ouFTn8vYntkruDbXpu1Ca