### PR TITLE
Migrate Plausible Analytics proxy from Netlify to Cloudflare Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ### Basics
 
-**www-ekipafanihy** is a [Jekyll](https://jekyllrb.com/)-generated static site. The published site is deployed using [Netlify](https://netlify.com) with a domain registered via [Squarespace](https://domains.squarespace.com).
-
-[![Netlify Status](https://api.netlify.com/api/v1/badges/0962e360-c36f-4d5f-a52d-2606a9539902/deploy-status)](https://app.netlify.com/sites/ekipafanihy/deploys)
+**www-ekipafanihy** is a [Jekyll](https://jekyllrb.com/)-generated static site. The published site is deployed using [Cloudflare Pages](https://pages.cloudflare.com) with a domain registered via [Squarespace](https://domains.squarespace.com).
 
 Creating a website for the new **Ekipa Fainhy Association**.

--- a/_redirects
+++ b/_redirects
@@ -1,9 +1,3 @@
-# netlify redirects https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file
-
-# Plausible Analytics based on https://plausible.io/docs/proxy/guides/vercel
-/pio/js/pa-Sgvh9CVWmXJRGx35iMWQM.js https://plausible.io/js/pa-Sgvh9CVWmXJRGx35iMWQM.js 200
-/pio/api/event https://plausible.io/api/event 200
-
 # Redirects from what the browser requests to what we serve
 /feed /feed.xml
 

--- a/functions/pio/[[path]].js
+++ b/functions/pio/[[path]].js
@@ -1,0 +1,19 @@
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+  const plausiblePath = url.pathname.replace(/^\/pio/, "") + url.search;
+
+  const response = await fetch("https://plausible.io" + plausiblePath, {
+    method: context.request.method,
+    headers: context.request.headers,
+    body: context.request.method === "POST" ? context.request.body : undefined,
+  });
+
+  // Return with CORS-safe headers
+  const newHeaders = new Headers(response.headers);
+  newHeaders.delete("set-cookie");
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: newHeaders,
+  });
+}


### PR DESCRIPTION
## Summary
This PR migrates the Plausible Analytics proxy implementation from Netlify redirects to Cloudflare Pages Functions, and updates the deployment platform documentation accordingly.

## Key Changes
- **Added Cloudflare Pages Function** (`functions/pio/[[path]].js`): Implements a dynamic proxy that forwards requests to Plausible Analytics while handling CORS headers appropriately
  - Routes all `/pio/*` requests to `https://plausible.io`
  - Preserves HTTP method, headers, and request body
  - Removes `set-cookie` headers from responses for CORS safety
  
- **Removed Netlify redirects** from `_redirects`: Deleted static redirect rules for Plausible Analytics endpoints that are now handled by the Cloudflare function
  
- **Updated README.md**: Changed deployment platform reference from Netlify to Cloudflare Pages

## Implementation Details
The Cloudflare Pages Function uses a catch-all route pattern (`[[path]]`) to intercept requests to `/pio/*` and dynamically proxy them to Plausible's API. The implementation strips the `/pio` prefix from the pathname while preserving query parameters, and carefully manages response headers to ensure CORS compatibility.

https://claude.ai/code/session_01W5zrz43jepi3szfvtNf33k