### PR TITLE
Document pending WWW redirect configuration task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,7 @@ Many pages have both English and Malagasy versions:
 ### Site Configuration
 
 `_config.yml` points to `https://ekipafanihy.org`. Update this file if the site URL changes.
+
+## Pending TODOs
+
+- **WWW redirect**: Make sure `www.ekipafanihy.org` redirects to the apex domain `ekipafanihy.org` (via `_redirects` or `netlify.toml`).


### PR DESCRIPTION
## Summary
Added documentation of a pending task to the project's developer guide regarding domain redirect configuration.

## Changes
- Added a "Pending TODOs" section to `CLAUDE.md` noting the need to configure a redirect from `www.ekipafanihy.org` to the apex domain `ekipafanihy.org`
- Documented that this redirect should be implemented via `_redirects` or `netlify.toml` configuration files

## Details
This is a documentation-only change that captures an outstanding configuration task for the project. The WWW subdomain redirect is a common best practice for web projects and should be configured at the hosting/CDN level (Netlify in this case).

https://claude.ai/code/session_018SFCEQxxkypEERKiA3wSTx