### PR TITLE
Update domain registrar from Squarespace to Cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 ### Basics
 
-**www-ekipafanihy** is a [Jekyll](https://jekyllrb.com/)-generated static site. The published site is deployed using [Cloudflare Pages](https://pages.cloudflare.com) with a domain registered via [Squarespace](https://domains.squarespace.com).
+**www-ekipafanihy** is a [Jekyll](https://jekyllrb.com/)-generated static site. The published site is deployed using [Cloudflare Pages](https://pages.cloudflare.com) with a domain registered via [Cloudflare](https://www.cloudflare.com).
 
 Creating a website for the new **Ekipa Fainhy Association**.


### PR DESCRIPTION
## Summary
Updated the README to reflect a change in the domain registrar for the www-ekipafanihy website.

## Changes
- Changed domain registrar reference from Squarespace Domains to Cloudflare in the project documentation
- Updated the link to point to Cloudflare's main domain services page instead of Squarespace's domain registration service

## Details
The domain for the Ekipa Fanihy Association website is now registered and managed through Cloudflare rather than Squarespace. This change consolidates the hosting infrastructure under a single provider (Cloudflare) for both deployment and domain management.

https://claude.ai/code/session_01A6VX2ADhsfBYsLDZxuDZnN