### PR TITLE
Remove pending WWW redirect TODO from documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,3 @@ Many pages have both English and Malagasy versions:
 ### Site Configuration
 
 `_config.yml` points to `https://ekipafanihy.org`. Update this file if the site URL changes.
-
-## Pending TODOs
-
-- **WWW redirect**: Make sure `www.ekipafanihy.org` redirects to the apex domain `ekipafanihy.org` (via `_redirects` or `netlify.toml`).


### PR DESCRIPTION
## Summary
Removed a completed TODO item from the CLAUDE.md documentation file regarding WWW domain redirect configuration.

## Changes
- Removed the "Pending TODOs" section that contained a note about implementing a WWW redirect from `www.ekipafanihy.org` to the apex domain `ekipafanihy.org`

## Details
This TODO has been addressed and is no longer needed in the documentation. The WWW redirect configuration (via `_redirects` or `netlify.toml`) has either been implemented or is no longer a pending concern for the project.

https://claude.ai/code/session_01GDyoWrsra5TY3bSAees5Z5