### PR TITLE
Update deployment platform from Netlify to Cloudflare Pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is the [Ekipa Fanihy](https://ekipafanihy.org) website — a Jekyll static site deployed via Netlify. It shares the same base structure as the [Brook Lab website](https://brooklab.org) ([brooklabteam/www](https://github.com/brooklabteam/www)).
+This is the [Ekipa Fanihy](https://ekipafanihy.org) website — a Jekyll static site deployed via Cloudflare Pages. It shares the same base structure as the [Brook Lab website](https://brooklab.org) ([brooklabteam/www](https://github.com/brooklabteam/www)).
 
 **Refer to [brooklabteam/www CLAUDE.md](https://github.com/brooklabteam/www/blob/main/CLAUDE.md) for full documentation** on local development, repository structure, adding news posts, top-level pages, navigation, site configuration, and deployment — the conventions are the same.
 


### PR DESCRIPTION
## Summary
Updated the project documentation to reflect a change in the deployment platform from Netlify to Cloudflare Pages.

## Changes
- Updated the overview section in CLAUDE.md to indicate that the Ekipa Fanihy website is now deployed via Cloudflare Pages instead of Netlify

## Notes
This is a documentation-only change that clarifies the current hosting infrastructure. The site continues to use Jekyll as a static site generator and maintains the same base structure as the Brook Lab website.

https://claude.ai/code/session_01SeBhMo5G4sXXs7ciNQPDTX